### PR TITLE
Make environment keys public

### DIFF
--- a/Sources/ModalPresentationView/EnvironmentKeys.swift
+++ b/Sources/ModalPresentationView/EnvironmentKeys.swift
@@ -16,7 +16,7 @@ enum ModalPresentationActionKey: EnvironmentKey {
   }
 }
 
-extension EnvironmentValues {
+public extension EnvironmentValues {
   var modalDismissAction: () -> Void {
     get { self[ModalDismissActionKey.self] }
     set { self[ModalDismissActionKey.self] = newValue }


### PR DESCRIPTION
Hey I made this small change. This way we can manually trigger the dismiss action.

**Why is this needed ?**

I am currently having the problem that I have a "Save" button. When the button is pressed I want to do some arbitrary operation and afterwards dismiss the modal screen. When implementing the label with a tap action the dismiss action is no longer executed. Small example which is not working:
```
ModalDismissButton {
    Button(action: {
        print("Save");
    }) {
        Text("Save").bold()
    }
})
```

With the above change I am able to write:
```
@Environment(\.modalDismissAction) private var dismiss
...
ModalDismissButton {
    Button(action: {
        print("Save")
        self.dismiss()

    }) {
        Text("Save").bold()
    }
})
```